### PR TITLE
Correct token docs

### DIFF
--- a/vonk/features/accesscontrol.rst
+++ b/vonk/features/accesscontrol.rst
@@ -198,7 +198,7 @@ A valid access token for Vonk at minimum will have:
 
 * the compartment claim. For example in case of Patient data access where the patient launch scope is used, the ``patient`` claim with the patient's id or identifier - see :ref:`feature_accesscontrol_compartment`
 * the ``iss`` claim with the base url of the OAuth server
-* the ``aud`` claim with the base url of the FHIR server
+* the ``aud`` the same value you've entered in ``SmartAuthorizationOptions.Audience``
 * and the ``scope`` field with the scopes granted by this access token.
 
 .. _feature_accesscontrol_decisions:


### PR DESCRIPTION
I was a bit confused by the LUMC example we were using - the valid audience value in the token is the one you've setup Vonk to look for.